### PR TITLE
Expiracion de mensajes en rmq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .project
 .settings
 target
+/bin

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>redis</groupId>
   <artifactId>mq</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.2-SNAPSHOT</version>
   <dependencies>
   	<dependency>
   		<groupId>junit</groupId>
@@ -14,7 +14,7 @@
   	<dependency>
   		<groupId>redis.clients</groupId>
   		<artifactId>jedis</artifactId>
-  		<version>1.4.0</version>
+  		<version>1.4.1-SNAPSHOT</version>
   		<type>jar</type>
   		<scope>compile</scope>
   	</dependency>

--- a/src/main/java/redis/rmq/Consumer.java
+++ b/src/main/java/redis/rmq/Consumer.java
@@ -20,6 +20,9 @@ public class Consumer {
 
     private void waitForMessages() {	
     	try {
+			// TODO el otro metodo podria hacer q no se consuman mensajes por un
+			// tiempo si no llegan, de esta manera solo se esperan 500ms y se
+			// controla que haya mensajes.
 			Thread.sleep(500);
 		} catch (InterruptedException e) {}
     }
@@ -29,7 +32,8 @@ public class Consumer {
             String message = readUntilEnd();
             if (message != null)
             	callback.onMessage(message);
-            waitForMessages();
+            else
+            	waitForMessages();
         }
     }
 

--- a/src/main/java/redis/rmq/Nest.java
+++ b/src/main/java/redis/rmq/Nest.java
@@ -64,9 +64,9 @@ public class Nest {
         return string;
     }
 
-    public Integer incr() {
+    public Long incr() {
         Jedis jedis = getResource();
-        Integer incr = jedis.incr(key());
+        Long incr = jedis.incr(key());
         returnResource(jedis);
         return incr;
     }
@@ -78,16 +78,16 @@ public class Nest {
         return multi;
     }
 
-    public Integer del() {
+    public Long del() {
         Jedis jedis = getResource();
-        Integer del = jedis.del(key());
+        Long del = jedis.del(key());
         returnResource(jedis);
         return del;
     }
 
-    public Integer exists() {
+    public Long exists() {
         Jedis jedis = getResource();
-        Integer exists = jedis.exists(key());
+        Long exists = jedis.exists(key());
         returnResource(jedis);
         return exists;
     }
@@ -114,16 +114,16 @@ public class Nest {
         return value;
     }
 
-    public Integer hdel(String field) {
+    public Long hdel(String field) {
         Jedis jedis = getResource();
-        Integer hdel = jedis.hdel(key(), field);
+        Long hdel = jedis.hdel(key(), field);
         returnResource(jedis);
         return hdel;
     }
 
-    public Integer hlen() {
+    public Long hlen() {
         Jedis jedis = getResource();
-        Integer hlen = jedis.hlen(key());
+        Long hlen = jedis.hlen(key());
         returnResource(jedis);
         return hlen;
     }
@@ -136,16 +136,16 @@ public class Nest {
     }
 
     // Redis Set Operations
-    public Integer sadd(String member) {
+    public Long sadd(String member) {
         Jedis jedis = getResource();
-        Integer reply = jedis.sadd(key(), member);
+        Long reply = jedis.sadd(key(), member);
         returnResource(jedis);
         return reply;
     }
 
-    public Integer srem(String member) {
+    public Long srem(String member) {
         Jedis jedis = getResource();
-        Integer reply = jedis.srem(key(), member);
+        Long reply = jedis.srem(key(), member);
         returnResource(jedis);
         return reply;
     }
@@ -158,9 +158,9 @@ public class Nest {
     }
 
     // Redis List Operations
-    public Integer rpush(String string) {
+    public Long rpush(String string) {
         Jedis jedis = getResource();
-        Integer rpush = jedis.rpush(key(), string);
+        Long rpush = jedis.rpush(key(), string);
         returnResource(jedis);
         return rpush;
     }
@@ -179,16 +179,16 @@ public class Nest {
         return lindex;
     }
 
-    public Integer llen() {
+    public Long llen() {
         Jedis jedis = getResource();
-        Integer llen = jedis.llen(key());
+        Long llen = jedis.llen(key());
         returnResource(jedis);
         return llen;
     }
 
-    public Integer lrem(int count, String value) {
+    public Long lrem(int count, String value) {
         Jedis jedis = getResource();
-        Integer lrem = jedis.lrem(key(), count, value);
+        Long lrem = jedis.lrem(key(), count, value);
         returnResource(jedis);
         return lrem;
     }
@@ -224,16 +224,16 @@ public class Nest {
         return zrange;
     }
 
-    public Integer zadd(float score, String member) {
+    public Long zadd(float score, String member) {
         Jedis jedis = getResource();
-        Integer zadd = jedis.zadd(key(), score, member);
+        Long zadd = jedis.zadd(key(), score, member);
         returnResource(jedis);
         return zadd;
     }
 
-    public Integer zcard() {
+    public Long zcard() {
         Jedis jedis = getResource();
-        Integer zadd = jedis.zcard(key());
+        Long zadd = jedis.zcard(key());
         returnResource(jedis);
         return zadd;
     }
@@ -266,9 +266,9 @@ public class Nest {
         return result;
     }
 
-    public Integer publish(String message) {
+    public Long publish(String message) {
         Jedis jedis = getResource();
-        Integer result = jedis.publish(key(), message);
+        Long result = jedis.publish(key(), message);
         returnResource(jedis);
         return result;
     }

--- a/src/test/java/redis/rmq/tests/ProducerTest.java
+++ b/src/test/java/redis/rmq/tests/ProducerTest.java
@@ -1,12 +1,15 @@
 package redis.rmq.tests;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import redis.clients.jedis.Jedis;
+import redis.rmq.Callback;
 import redis.rmq.Consumer;
 import redis.rmq.Producer;
 
@@ -92,17 +95,140 @@ public class ProducerTest extends Assert {
     }
 
     class SlowProducer extends Producer {
-        public SlowProducer(Jedis jedis, String topic) {
-            super(jedis, topic);
+        private long sleep;
+
+		public SlowProducer(Jedis jedis, String topic) {
+            this(jedis, topic, 500L);
         }
 
-        protected Integer getNextMessageId() {
+        public SlowProducer(Jedis jedis, String topic, long sleep) {
+			super(jedis, topic);
+			this.sleep = sleep;
+		}
+
+		protected Integer getNextMessageId() {
             Integer nextMessageId = super.getNextMessageId();
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException e) {
-            }
+            sleep(sleep);
             return nextMessageId;
         }
     }
+    
+    class SlowConsumer extends Consumer {
+        private long sleep;
+
+		public SlowConsumer(Jedis jedis, String id, String topic) {
+            this(jedis, id, topic, 500L);
+        }
+
+        public SlowConsumer(Jedis jedis, String id, String topic, long sleep) {
+			super(jedis, id, topic);
+			this.sleep = sleep;
+		}
+
+		@Override
+		public String consume() {
+			sleep(sleep);
+			return super.consume();
+		}
+		
+		@Override
+		public void consume(Callback callback) {
+			sleep(sleep);
+			super.consume(callback);
+		}
+    }
+    
+    
+    @Test
+    public void expiredMessages() throws InterruptedException {
+        Consumer c = new SlowConsumer(new Jedis("localhost"), "a consumer", "foo", 3000L);
+        Producer p = new Producer(new Jedis("localhost"), "foo");
+        p.publish("un mensaje", 1);
+        assertNull(c.consume());
+    }
+    
+    @Test
+    public void expiredMessagesCallback() throws InterruptedException {
+        Producer producer = new Producer(new Jedis("localhost"), "foo1");
+        Consumer consumer = new Consumer(new Jedis("localhost"), "a consumer", "foo1");
+        BufferCallback callback = new BufferCallback(3);
+        Thread t = new Thread(new BackgroundConsumer(consumer, callback));
+                
+        producer.publish("1", 1);
+        producer.publish("2", 0);
+        producer.publish("3", 1);
+        producer.publish("4", 0);
+        producer.publish("5", 1);
+        producer.publish("6", 0);
+        sleep(3100L);
+        t.start();
+        sleep(3100L);
+        
+       assertEquals(3, callback.messages.size());
+        for (String message : callback.messages) {
+        	if (!(Integer.valueOf(message)%2 == 0)) {
+        		fail("Mensaje impar no puede ser consumido, deberia expirar. ["+message+"]");
+        	}
+		}        
+    }
+    
+
+    private void sleep(long sleep) {
+    	try {
+			Thread.sleep(sleep);
+		} catch (InterruptedException e) {}
+	}
+
+	class BufferCallback implements Callback {
+    	List<String> messages = new CopyOnWriteArrayList<String>();
+    	private int msgs;
+	
+    	public BufferCallback (int msgs) {
+    		this.msgs = msgs;    		
+    	}
+    	
+  		public void onMessage(String message) {
+  			messages.add(message);	
+  			
+  			if (messages.size() == msgs)
+  				//tiro exception para parar el callback, ni idea como hacerlo bien :P.
+  				throw new RuntimeException("Total de los mensajes consumidos");
+		}
+	};
+	
+	class BackgroundConsumer implements Runnable {
+		private Consumer consumer;
+		private Callback callback;
+		
+		BackgroundConsumer (Consumer consumer, Callback callback) {
+			this.consumer = consumer;
+			this.callback = callback;
+		}
+	    
+		public void run() {
+	    	consumer.consume(callback);
+	    }
+	}
+    
+    
+    @Test
+    public void expiredFirstMessage() throws InterruptedException {
+        Consumer c = new SlowConsumer(new Jedis("localhost"), "a consumer", "foo", 2000L);
+        Producer p = new Producer(new Jedis("localhost"), "foo");
+        p.publish("1", 1);
+        p.publish("2", 0);
+        
+        //el segundo mensaje deberia estar
+        assertEquals("2", c.consume());
+    }
+    
+    @Test
+    public void notExpiredMessages() throws InterruptedException {
+        Consumer c = new SlowConsumer(new Jedis("localhost"), "a consumer", "foo");
+        Producer p = new Producer(new Jedis("localhost"), "foo");
+        p.publish("foo", 0);
+        assertEquals("foo", c.consume());
+    }
+    
+    
 }


### PR DESCRIPTION
Buenas, le agregue la expiracion de mensajes, ahora existe el metodo: redis.rmq.Producer.publish(String, int) que revise los segundos de vida del mensaje. Estaria bueno que se int en realidad fuera un long, pero hay q cambiarlo en jedis.

Ademas los metodos del consumer quedaron asi:
redis.rmq.Consumer.read(): no es bloqueante, retorna null si el mensajes expiro o no hay mensajes
redis.rmq.Consumer.consume(): retorna null si no hay mensajes, o el siguiente mensajes, ignora los expirados
redis.rmq.Consumer.consume(Callback): obviamente es bloqueante e ignora los mensajes expirados
